### PR TITLE
Add support for additional SSH options

### DIFF
--- a/NetDBHelper.pm
+++ b/NetDBHelper.pm
@@ -89,6 +89,7 @@ my $WHIRLEY_COUNT=-1;
 my $session_type;
 my $general_session;
 my $hostprompt;
+my $ssh_options;
 
 my ( $whirley, $myprompt );
 
@@ -396,6 +397,11 @@ sub processDevConfig {
             ( $tmp, $ssh_port ) = split(/ssh_port\=/, $line );
             ( $ssh_port ) = split(/\,/, $ssh_port );
         }
+	#SSH Options
+	if ( $line =~ /ssh_options/ ) {
+            ( $tmp, $ssh_options ) = split(/ssh_options\=/, $line );
+            ( $ssh_options ) = split(/\,/, $ssh_options );
+	}
 	# SSH Timeout
         if ( $line =~ /ssh_timeout/ ) {
             ( $tmp, $ssh_timeout ) = split(/ssh_timeout\=/, $line );
@@ -417,10 +423,10 @@ sub processDevConfig {
                       devtype => $l_devtype, gethost => $gethost,
                       nobackup => $nobackup, dobackup => $dobackup,
                       authgroup => $authgroup, wifi => $wifi, 
-		      ssh_timeout => $ssh_timeout, ssh_port => $ssh_port, 
-		      login_timeout => $login_timeout };
+		              ssh_timeout => $ssh_timeout, ssh_port => $ssh_port,
+		              ssh_options => $ssh_options, login_timeout => $login_timeout };
 	
-        print "|DEBUG|: Device: $host, fqdn: $fqdn, mac: $nmac, wifi: $wifi, arp: $narp, vrfs: $vrfs, ipv6: $v6, devtype: $l_devtype, authgroup: $authgroup, ssh_port: $ssh_port, ssh_timeout: $ssh_timeout, login_timeout: $login_timeout\n" if $DEBUG>2;
+        print "|DEBUG|: Device: $host, fqdn: $fqdn, mac: $nmac, wifi: $wifi, arp: $narp, vrfs: $vrfs, ipv6: $v6, devtype: $l_devtype, authgroup: $authgroup, ssh_port: $ssh_port, ssh_options: $ssh_options, ssh_timeout: $ssh_timeout, login_timeout: $login_timeout\n" if $DEBUG>2;
 
         return $dref;
     }
@@ -630,6 +636,7 @@ sub get_SSH_session {
     #print "\n\n****DREF TIMEOUT****: $$dref{login_timeout}\n\n";
 
     $ssh_port = $$dref{ssh_port} if $$dref{ssh_port};
+    $ssh_options = $$dref{ssh_options} if $$dref{ssh_options};
     
     if ( !$hostname ){  # verify a hostname is given
         croak("Minimum set of arguments undefined in get_SSH_session\n");
@@ -659,6 +666,7 @@ sub get_SSH_session {
                                         user => $user,
                                         raw_pty => 1,
                                         timeout => $login_timeout,
+					                    ssh_option => $ssh_options
                                         );
         $session->login();
         my @output;
@@ -689,6 +697,7 @@ sub get_SSH_session {
                                                  user => $username2,
                                                  raw_pty => 1,
                                                  timeout => $login_timeout,
+						                        ssh_option => $ssh_options
                                                 );
                 $session->login();
 
@@ -1125,7 +1134,7 @@ sub parseConfig {
     $config->define( "ipv6_file=s", "datadir=s", "skip_port=s%", "use_port=s%", "ssh_timeout=s", "use_fqdn" );
     $config->define( "devuser=s", "devpass=s", "devuser2=s", "devpass2=s", "enablepass=s", "telnet_timeout=s" );
     $config->define( "authgroup=s%", "authgroup_user=s%", "authgroup_pass=s%", "authgroup_enable=s%" );
-    $config->define( "login_timeout=s", "ssh_port=s" );
+    $config->define( "login_timeout=s", "ssh_port=s", "ssh_options=s" );
 
     $config->file( "$config_file" );
 
@@ -1168,6 +1177,11 @@ sub parseConfig {
     if ( $config->ssh_port() ) {
 	$ssh_port = $config->ssh_port();
     }
+
+    # SSH Options
+    if ( $config->ssh_options() ) {
+	    $ssh_options = $config->ssh_options();
+	}
 
     # Login Timeout, fallback to ssh_timeout
     if ( $config->login_timeout() ) {

--- a/README.md
+++ b/README.md
@@ -9,6 +9,13 @@
 All credit goes to Jonathan Yantis.
 
 ------------
+
+### About this fork
+
+This fork adds a configurable parameter for additional SSH options. 
+Reason for this is that some older cisco devices only support SHA1 ciphers, so a ssh connection can't be established.
+If your device doesn't support newer ciphers you will get an error like "no matching key exchange method found. Their offer: diffie-hellman-group1-sha1" when trying to connect via openssh.
+
 ### Installation
 
 To install NetDB on a vanilla Red Hat based distribution run the following commands

--- a/netdb.conf
+++ b/netdb.conf
@@ -172,6 +172,17 @@ scraper_count = 20
 #
 # ssh_port = 22
 
+# SSH Options
+#
+# Use this to set additional SSH Options
+# Older Cisco iOS versions don't support ssh connections with older ciphers, thus you can set them here globally
+# If you want to set it for single devices only, this can also be added to devicelist.csv as ssh_options=...
+# i.e. the following line allows sha1 ssh logins, older devices will fail with SSHConnectionAborted for both logins.
+# Check if you're affected by this when manually connecting via ssh, it should give an error like
+# no matching key exchange method found. Their offer: diffie-hellman-group1-sha1
+
+# ssh_options = -oKexAlgorithms=+diffie-hellman-group1-sha1
+
 
 # Telnet timeout in seconds (default is 20 seconds)
 # If the timeout is too short, commands can timeout on big tables


### PR DESCRIPTION
This adds ssh_options to the netdb.conf file. Older cisco devices cant be reached with newer versions of ssh because they don't support newer ciphers.
This will result i.e. in the following error when trying to connect via ssh: 
`no matching key exchange method found. Their offer: diffie-hellman-group1-sha1`
This PR adds the option to optionally specify SSH parameters to allow older ciphers. Parameters can be configured globally in netdb.conf or for single devices only in devicelist.csv file.